### PR TITLE
Update penguin-stats API v1.2.2.md

### DIFF
--- a/penguin-stats API v1.2.2.md
+++ b/penguin-stats API v1.2.2.md
@@ -1107,7 +1107,7 @@ GET /PenguinStats/api/stage/{stageId}
 ### URI
 
 ```
-GET  PenguinStats/api/item
+GET  PenguinStats/api/items
 ```
 
 ### 响应消息
@@ -1134,7 +1134,7 @@ GET  PenguinStats/api/item
 - 请求示例
 
   ```
-  GET  PenguinStats/api/item
+  GET  PenguinStats/api/items
   ```
 
 - 返回示例


### PR DESCRIPTION
PenguinStats/api/item responds with 404. I believe this is typo in documentation, PenguinStats/api/items responds the way PenguinStats/api/item is supposed to.