### PR TITLE
Upgrade Spring Boot to 2.2.13 according to security concerns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.6.RELEASE</version>
+		<version>2.2.13.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.penguinstats</groupId>
 	<artifactId>backend</artifactId>
-	<version>2.5.0</version>
+	<version>2.6.0</version>
 	<packaging>war</packaging>
 	<name>Penguin Statistics</name>
 	<description>Penguin Statistics back-end</description>

--- a/src/main/java/io/penguinstats/service/EventPeriodServiceImpl.java
+++ b/src/main/java/io/penguinstats/service/EventPeriodServiceImpl.java
@@ -25,7 +25,7 @@ public class EventPeriodServiceImpl implements EventPeriodService {
 
 	@Override
 	public List<EventPeriod> getAllSortedEventPeriod() {
-		List<EventPeriod> result = eventPeriodDao.findAll(new Sort(Direction.ASC, "start"));
+		List<EventPeriod> result = eventPeriodDao.findAll(Sort.by(Direction.ASC, "start"));
 		LastUpdateTimeUtil.setCurrentTimestamp(LastUpdateMapKeyName.EVENT_PERIOD_LIST);
 		return result;
 	}

--- a/src/main/java/io/penguinstats/service/ItemDropServiceImpl.java
+++ b/src/main/java/io/penguinstats/service/ItemDropServiceImpl.java
@@ -54,7 +54,7 @@ public class ItemDropServiceImpl implements ItemDropService {
 
     @Override
     public void recallItemDrop(String userID, String itemDropHashId) throws Exception {
-        Pageable pageable = PageRequest.of(0, 1, new Sort(Sort.Direction.DESC, "timestamp"));
+        Pageable pageable = PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "timestamp"));
         List<ItemDrop> itemDropList = getVisibleItemDropsByUserID(userID, pageable).getContent();
         if (itemDropList.size() == 0) {
             throw new BusinessException(ErrorCode.NOT_FOUND,


### PR DESCRIPTION
#73 Security concerns make it urgent to upgrade the version of Spring Boot to 2.2 or newer.